### PR TITLE
docs: Update Anthropic, Bedrock, and Vertex AI provider docs with new…

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -19,7 +19,11 @@ Anthropic is an AI safety and research company that builds reliable, interpretab
 
 Roo Code supports the following Anthropic Claude models:
 
-*   `claude-3-7-sonnet-20250219` (Recommended)
+*   `claude-opus-4-20250514`
+*   `claude-opus-4-20250514:thinking` (Extended Thinking variant)
+*   `claude-sonnet-4-20250514` (Recommended)
+*   `claude-sonnet-4-20250514:thinking` (Extended Thinking variant)
+*   `claude-3-7-sonnet-20250219`
 *   `claude-3-7-sonnet-20250219:thinking` (Extended Thinking variant)
 *   `claude-3-5-sonnet-20241022`
 *   `claude-3-5-haiku-20241022`

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -43,6 +43,8 @@ Roo Code supports the following models through Bedrock (based on source code):
     *   `amazon.titan-text-embeddings-v1:0`
     *   `amazon.titan-text-embeddings-v2:0`
 *   **Anthropic:**
+    *   `anthropic.claude-opus-4-20250514-v1:0`
+    *   `anthropic.claude-sonnet-4-20250514-v1:0`
     *   `anthropic.claude-3-7-sonnet-20250219-v1:0`
     *   `anthropic.claude-3-5-sonnet-20241022-v2:0`
     *   `anthropic.claude-3-5-haiku-20241022-v1:0`

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -32,6 +32,10 @@ Roo Code supports the following models through Vertex AI (based on source code):
     *   `gemini-1.5-flash-002`
     *   `gemini-1.5-pro-002`
 *   **Anthropic Claude Models:**
+    *   `claude-opus-4@20250514:thinking`
+    *   `claude-opus-4@20250514`
+    *   `claude-sonnet-4@20250514:thinking`
+    *   `claude-sonnet-4@20250514`
     *   `claude-3-7-sonnet@20250219:thinking`
     *   `claude-3-7-sonnet@20250219`
     *   `claude-3-5-sonnet-v2@20241022`


### PR DESCRIPTION
Added Claude 4 models information for following providers 
Anthropic 
Bedrock
Vertex 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Anthropic, Bedrock, and Vertex AI provider docs to include new Claude 4 models.
> 
>   - **Anthropic Provider**:
>     - Added `claude-opus-4-20250514`, `claude-opus-4-20250514:thinking`, `claude-sonnet-4-20250514`, and `claude-sonnet-4-20250514:thinking` to supported models in `anthropic.md`.
>   - **Bedrock Provider**:
>     - Added `anthropic.claude-opus-4-20250514-v1:0` and `anthropic.claude-sonnet-4-20250514-v1:0` to supported models in `bedrock.md`.
>   - **Vertex AI Provider**:
>     - Added `claude-opus-4@20250514:thinking`, `claude-opus-4@20250514`, `claude-sonnet-4@20250514:thinking`, and `claude-sonnet-4@20250514` to supported models in `vertex.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 8d4ba4eb8fca9817a1e28eb4599090c718bdd965. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->