### PR TITLE
Fix typo in Roocabulary

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -12,7 +12,7 @@ Welcome to the Roo Code community section! Here you'll find community projects t
 | [Dynamic Rules](/community/dynamic-rules) | Define new rules and delete them on the fly with simple syntax in your messages |
 | [Roo Commander](/community/roo-commander) | Sophisticated collection of custom modes designed to manage software development projects |
 | [Maestro Project](/community/maestro) | Orchestrates a team of specialized modes for comprehensive software development lifecycle management |
-| [Roocabularo](/community/roocabulary) | a collection of words, phrases, and jargon created to define and enhance the Roo Code experience |
+| [Roocabulary](/community/roocabulary) | a collection of words, phrases, and jargon created to define and enhance the Roo Code experience |
 
 ## Custom Modes Gallery {#custom-modes-gallery}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `docs/community/index.md`, changing 'Roocabularo' to 'Roocabulary'.
> 
>   - **Documentation**:
>     - Fix typo in `docs/community/index.md`, changing 'Roocabularo' to 'Roocabulary'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 2946601393d826b8c06c9a1340e242ddcfe2bab9. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->