### PR TITLE
Fix(docs): Correct broken link in vscode-lm.md

### DIFF
--- a/docs/providers/vscode-lm.md
+++ b/docs/providers/vscode-lm.md
@@ -4,7 +4,7 @@ sidebar_label: VS Code Language Model API
 
 # Using VS Code Language Model API With Roo Code
 
-Roo Code includes *experimental* support for the [VS Code Language Model API](https://code.visualstudio.com/api/language-extensions/language-model-access). This API allows extensions to provide access to language models directly within VS Code.  This means you can potentially use models from:
+Roo Code includes *experimental* support for the [VS Code Language Model API](https://code.visualstudio.com/api/extension-guides/language-model). This API allows extensions to provide access to language models directly within VS Code.  This means you can potentially use models from:
 
 *   **GitHub Copilot:** If you have a Copilot subscription and the extension installed.
 *   **Other VS Code Extensions:** Any extension that implements the Language Model API.


### PR DESCRIPTION
This pull request fixes a broken link in the `docs/providers/vscode-lm.md` file, as reported in issue #226.
closes #226
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `vscode-lm.md` to correct VS Code Language Model API guide URL.
> 
>   - **Docs**:
>     - Fix broken link in `vscode-lm.md` from `https://code.visualstudio.com/api/language-extensions/language-model-access` to `https://code.visualstudio.com/api/extension-guides/language-model`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 95b6f225affc916618cbc60430acbb1e0a11afb5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->