### PR TITLE
Add Claude Code provider docs and 3.21.4 release notes

### DIFF
--- a/docs/providers/claude-code.md
+++ b/docs/providers/claude-code.md
@@ -1,0 +1,145 @@
+---
+sidebar_label: Claude Code
+---
+
+# Claude Code Provider
+
+The Claude Code provider allows you to use Anthropic's Claude models through their official CLI (Command Line Interface) instead of the web API. This provides direct access to your Claude Max subscription right from Roo Code.
+
+**Website:** [https://docs.anthropic.com/en/docs/claude-code/setup](https://docs.anthropic.com/en/docs/claude-code/setup)
+
+---
+
+## Key Features
+- **Direct CLI Access**: Uses Anthropic's official Claude CLI tool for model interactions
+- **Advanced Reasoning**: Full support for Claude's thinking mode and reasoning capabilities
+- **Cost Transparency**: Shows exact usage costs as reported by the CLI
+- **Flexible Configuration**: Works with your existing Claude CLI setup
+
+---
+
+## Why Use This Provider
+
+- **No API Keys**: Uses your existing Claude CLI authentication
+- **Cost Benefits**: Leverage CLI subscription rates and transparent cost reporting
+- **Latest Features**: Access new Claude capabilities as they're released in the CLI
+- **Advanced Reasoning**: Full support for Claude's thinking modes
+
+## How it Works
+
+The Claude Code provider works by:
+
+1. **Running Commands**: Executes the `claude` CLI command with your prompts
+2. **Processing Output**: Handles the CLI's JSON output in chunks with advanced parsing
+3. **Handling Reasoning**: Captures and displays Claude's thinking process when available
+4. **Tracking Usage**: Reports token usage and costs as provided by the CLI
+
+The provider integrates with Roo Code's interface, giving you the same experience as other providers while using the Claude CLI under the hood.
+
+---
+
+## Configuration
+
+You only need to configure one optional setting:
+
+### **Claude Code Path**
+- **Setting**: `claudeCodePath`
+- **Description**: Path to your Claude CLI executable
+- **Default**: `claude` (assumes it's in your system PATH)
+- **When to change**: If you installed Claude CLI in a custom location
+
+**Example custom paths:**
+- Windows: `C:\tools\claude\claude.exe`
+- macOS/Linux: `/usr/local/bin/claude` or `~/bin/claude`
+
+---
+
+## Supported Models
+
+The Claude Code provider supports these Claude models:
+
+- **Claude Sonnet 4** (latest, recommended)
+- **Claude Opus 4** (most capable)
+- **Claude 3.7 Sonnet**
+- **Claude 3.5 Sonnet**
+- **Claude 3.5 Haiku** (fast responses)
+
+The specific models available depend on your Claude CLI subscription and plan.
+
+---
+
+## Prerequisites
+
+Before using the Claude Code provider:
+
+1. **Install Claude CLI**: Download and install from Anthropic
+2. **Authenticate**: Run `claude auth` to sign in to your account
+3. **Verify Setup**: Test with `claude --version` to ensure it's working
+4. **Optional**: Add CLI location to PATH or configure custom path in settings
+
+## Configuration in Roo Code
+
+**Initial Setup Option:**
+The Claude Code provider can be selected during your initial Roo Code setup without requiring additional configuration, making it one of the easiest providers to get started with.
+
+**Manual Configuration:**
+1. **Open Roo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Roo Code panel.
+2. **Select Provider:** Choose "Claude Code" from the "API Provider" dropdown.
+3. **Configure Path (Optional):** If needed, set the "Claude Code Path" to your CLI executable location.
+4. **Select Model:** Choose your desired Claude model from the "Model" dropdown.
+
+---
+
+
+## Common Questions
+
+**"Do I need a Claude API key for this provider?"**
+- No! This provider uses your Claude CLI setup instead of the web API
+- You'll need the Claude CLI installed and authenticated on your system
+
+**"How do I install the Claude CLI?"**
+- Visit [Anthropic's CLI documentation](https://docs.anthropic.com/en/docs/claude-code/setup) for installation instructions
+- The CLI handles its own authentication and setup
+
+**"Why would I use this instead of the regular Anthropic provider?"**
+- Potential cost benefits depending on your subscription
+
+**"What if the CLI isn't in my PATH?"**
+- Set a custom path in the Claude Code Path setting
+- Point to the full path where you installed the CLI
+
+
+---
+
+## Troubleshooting
+
+### **"Claude Code process exited with error"**
+**Common causes:**
+- Claude CLI not installed or not in PATH
+
+**Solutions:**
+1. Verify CLI installation: `claude --version`
+2. Re-authenticate: `claude auth`
+3. Check your subscription includes the selected model
+4. Try a different model
+
+
+### **Custom path not working**
+**Problem**: Roo Code can't find your Claude CLI
+**Solutions:**
+- Use the full absolute path to the CLI executable
+- Verify the path exists and the file is executable
+- On Windows, you may need to include the `.exe` extension
+
+
+## Advanced Usage
+
+### **Custom Installation Paths**
+If you installed Claude CLI in a non-standard location:
+
+```bash
+# Example custom paths
+/opt/claude/bin/claude          # Linux custom install
+/Applications/Claude/claude     # macOS app bundle
+C:\claude\claude.exe           # Windows custom location
+```

--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -5,6 +5,7 @@ This section contains notes about recent updates to Roo Code, listed by version 
 
 ## Version 3.21
 
+*   [3.21.4](/update-notes/v3.21.4) (2025-06-23)
 *   [3.21.3](/update-notes/v3.21.3) (2025-06-21)
 *   [3.21.2](/update-notes/v3.21.2) (2025-06-21)
 *   [3.21.1](/update-notes/v3.21.1) (2025-06-18)

--- a/docs/update-notes/v3.21.4.mdx
+++ b/docs/update-notes/v3.21.4.mdx
@@ -4,7 +4,7 @@ This release introduces the new Claude Code provider for local CLI integration a
 
 ## Use Your Claude Max Subscription with Roo Code
 
-You can now use your Claude Max subscription directly in Roo Code through our new Claude Code provider ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
+You can now use your Claude Max subscription directly in Roo Code through our new [Claude Code provider](/providers/claude-code) (thanks Cline!) ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
 
 - **Leverage Your Existing Subscription**: Connect your Claude Max plan to Roo Code through the Claude CLI
 - **No Additional API Costs**: Use your subscription benefits instead of paying per-token API rates

--- a/docs/update-notes/v3.21.4.mdx
+++ b/docs/update-notes/v3.21.4.mdx
@@ -1,0 +1,20 @@
+# Roo Code 3.21.4 Release Notes (2025-06-23)
+
+This release introduces the new Claude Code provider for local CLI integration and fixes several critical issues.
+
+## Use Your Claude Max Subscription with Roo Code
+
+You can now use your Claude Max subscription directly in Roo Code through our new Claude Code provider ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
+
+- **Leverage Your Existing Subscription**: Connect your Claude Max plan to Roo Code through the Claude CLI
+- **No Additional API Costs**: Use your subscription benefits instead of paying per-token API rates
+- **Access Premium Models**: Use Claude Sonnet 4, Opus 4, and other advanced models included in your plan
+- **Zero Setup Complexity**: Select Claude Code as your provider during initial setup - no API keys needed
+- **Advanced Reasoning Support**: Full access to Claude's thinking modes and reasoning capabilities
+
+Perfect for Claude Max subscribers who want to maximize their subscription value while coding.
+
+## Bug Fixes
+
+* **Apply Diff Accuracy**: Fixed start line parameter not working correctly when applying multiple file diffs (thanks samhvw8!) ([#5019](https://github.com/RooCodeInc/Roo-Code/pull/5019))
+* **Ollama Compatibility**: Resolved validation errors that prevented Ollama from working with certain models (thanks daniel-lxs, MartinHarding1998!) ([#5014](https://github.com/RooCodeInc/Roo-Code/pull/5014))

--- a/docs/update-notes/v3.21.mdx
+++ b/docs/update-notes/v3.21.mdx
@@ -12,6 +12,18 @@ We're excited to announce the official launch of the [Roo Marketplace](/features
 
 The Roo Marketplace makes it easy to extend Roo Code's functionality with powerful integrations created by our vibrant community.
 
+## Use Your Claude Max Subscription with Roo Code
+
+You can now use your Claude Max subscription directly in Roo Code through our new Claude Code provider ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
+
+- **Leverage Your Existing Subscription**: Connect your Claude Max plan to Roo Code through the Claude CLI
+- **No Additional API Costs**: Use your subscription benefits instead of paying per-token API rates
+- **Access Premium Models**: Use Claude Sonnet 4, Opus 4, and other advanced models included in your plan
+- **Zero Setup Complexity**: Select Claude Code as your provider during initial setup - no API keys needed
+- **Advanced Reasoning Support**: Full access to Claude's thinking modes and reasoning capabilities
+
+Perfect for Claude Max subscribers who want to maximize their subscription value while coding.
+
 ## [Gemini 2.5 Models Support](https://blog.google/products/gemini/gemini-2-5-model-family-expands/)
 
 We've added support for [Google's latest Gemini 2.5 models](https://blog.google/products/gemini/gemini-2-5-model-family-expands/) ([#4762](https://github.com/RooCodeInc/Roo-Code/pull/4762), [#4770](https://github.com/RooCodeInc/Roo-Code/pull/4770), [#4767](https://github.com/RooCodeInc/Roo-Code/pull/4767)):
@@ -56,6 +68,8 @@ Added support for reading Excel (.xlsx) files in tools ([#4751](https://github.c
 
 ## Bug Fixes
 
+* **Apply Diff Accuracy**: Fixed start line parameter not working correctly when applying multiple file diffs (thanks samhvw8!) ([#5019](https://github.com/RooCodeInc/Roo-Code/pull/5019))
+* **Ollama Compatibility**: Resolved validation errors that prevented Ollama from working with certain models (thanks daniel-lxs, MartinHarding1998!) ([#5014](https://github.com/RooCodeInc/Roo-Code/pull/5014))
 *   **Ollama & LM Studio Context Length**: The context length for models served by Ollama and LM Studio is now automatically detected and displayed correctly, so you no longer need to configure it manually (thanks thecolorblue, Fade78!) ([#4314](https://github.com/RooCodeInc/Roo-Code/pull/4314)).
 *   **MCP Tool UI**: Resolved an issue where the eye icon for MCP tools was showing the incorrect state and was visible in chat contexts where it should have been hidden (thanks daniel-lxs!) ([#4994](https://github.com/RooCodeInc/Roo-Code/pull/4994)).
 * **Marketplace**: Fixed an issue where the marketplace would go blank after being populated and resolved timeout issues (thanks yangbinbin48!) ([#4941](https://github.com/RooCodeInc/Roo-Code/pull/4941))

--- a/docs/update-notes/v3.21.mdx
+++ b/docs/update-notes/v3.21.mdx
@@ -14,7 +14,7 @@ The Roo Marketplace makes it easy to extend Roo Code's functionality with powerf
 
 ## Use Your Claude Max Subscription with Roo Code
 
-You can now use your Claude Max subscription directly in Roo Code through our new Claude Code provider ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
+You can now use your Claude Max subscription directly in Roo Code through our new [Claude Code provider](/providers/claude-code) (thanks Cline!) ([#4864](https://github.com/RooCodeInc/Roo-Code/pull/4864), [#5038](https://github.com/RooCodeInc/Roo-Code/pull/5038)):
 
 - **Leverage Your Existing Subscription**: Connect your Claude Max plan to Roo Code through the Claude CLI
 - **No Additional API Costs**: Use your subscription benefits instead of paying per-token API rates

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -116,6 +116,7 @@ const sidebars: SidebarsConfig = {
       label: 'Model Providers',
       items: [
         'providers/anthropic',
+        'providers/claude-code',
         'providers/bedrock',
         'providers/deepseek',
         'providers/chutes',
@@ -195,6 +196,7 @@ const sidebars: SidebarsConfig = {
           label: '3.21',
           items: [
             { type: 'doc', id: 'update-notes/v3.21', label: '3.21 Combined' },
+            { type: 'doc', id: 'update-notes/v3.21.4', label: '3.21.4' },
             { type: 'doc', id: 'update-notes/v3.21.3', label: '3.21.3' },
                         { type: 'doc', id: 'update-notes/v3.21.2', label: '3.21.2' },
             { type: 'doc', id: 'update-notes/v3.21.1', label: '3.21.1' },


### PR DESCRIPTION
Introduced documentation for the new Claude Code provider, enabling integration with Anthropic's Claude CLI. Added release notes for version 3.21.4, highlighting the Claude Code provider and recent bug fixes. Updated sidebars and update notes to reflect the new provider and release.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add documentation for Claude Code provider and release notes for version 3.21.4, updating sidebars accordingly.
> 
>   - **Documentation**:
>     - Added `claude-code.md` for the new Claude Code provider, detailing features, configuration, and usage.
>     - Updated `index.md` in `update-notes` to include version 3.21.4.
>     - Added `v3.21.4.mdx` in `update-notes` for release notes, highlighting the Claude Code provider and bug fixes.
>   - **Sidebars**:
>     - Updated `sidebars.ts` to include `claude-code` under Model Providers.
>     - Added version 3.21.4 to the update notes section in `sidebars.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 124f886a9fe3769bab979f55d0f37217fdee2875. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->