### PR TITLE
Change sparkle to wand symbol in enhance prompt documentation

### DIFF
--- a/docs/features/enhance-prompt.md
+++ b/docs/features/enhance-prompt.md
@@ -1,6 +1,6 @@
 # Enhance Prompt
 
-The "Enhance Prompt" feature in Roo Code helps you improve the quality and effectiveness of your prompts before sending them to the AI model.  By clicking the <Codicon name="sparkle" /> icon in the chat input, you can automatically refine your initial request, making it clearer, more specific, and more likely to produce the desired results.
+The "Enhance Prompt" feature in Roo Code helps you improve the quality and effectiveness of your prompts before sending them to the AI model.  By clicking the <Codicon name="wand" /> icon in the chat input, you can automatically refine your initial request, making it clearer, more specific, and more likely to produce the desired results.
 
 ---
 
@@ -17,7 +17,7 @@ The "Enhance Prompt" feature in Roo Code helps you improve the quality and effec
 ## How to Use Enhance Prompt
 
 1.  **Type your initial prompt:**  Enter your request in the Roo Code chat input box as you normally would.  This can be a simple question, a complex task description, or anything in between.
-2.  **Click the <Codicon name="sparkle" /> Icon:**  Instead of pressing Enter, click the <Codicon name="sparkle" /> icon located in the bottom right of the chat input box.
+2.  **Click the <Codicon name="wand" /> Icon:**  Instead of pressing Enter, click the <Codicon name="wand" /> icon located in the bottom right of the chat input box.
 3.  **Review the Enhanced Prompt:**  Roo Code will replace your original prompt with an enhanced version.  Review the enhanced prompt to make sure it accurately reflects your intent. You can further refine the enhanced prompt before sending.
 4.  **Send the Enhanced Prompt:**  Press Enter or click the Send icon (<Codicon name="send" />) to send the enhanced prompt to Roo Code.
 


### PR DESCRIPTION
I can't find the symbol which looks like a sparkle in the described location, instead there is a wand.
<img width="409" height="118" alt="image" src="https://github.com/user-attachments/assets/5ff3a172-9b4e-4735-a297-1db41788120c" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `enhance-prompt.md` to change icon description from 'sparkle' to 'wand'.
> 
>   - **Documentation Update**:
>     - In `docs/features/enhance-prompt.md`, change `<Codicon name="sparkle" />` to `<Codicon name="wand" />` to reflect the actual icon used in the UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for a212d48f1c91e3920e368d43abf3641f13a5fbf7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->