### PR TITLE
Add release notes for v3.25.19

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -19,6 +19,7 @@ This section contains notes about recent updates to Roo Code, listed by version 
 
 ## Version 3.25
 
+*   [3.25.19](/update-notes/v3.25.19) (2025-01-20)
 *   [3.25.18](/update-notes/v3.25.18) (2025-08-19)
 *   [3.25.17](/update-notes/v3.25.17) (2025-08-18)
 *   [3.25.16](/update-notes/v3.25.16) (2025-08-17)

--- a/docs/update-notes/v3.25.19.mdx
+++ b/docs/update-notes/v3.25.19.mdx
@@ -1,0 +1,16 @@
+---
+description: Bug fix for Roo Code Cloud provider welcome screen
+keywords:
+  - roo code 3.25.19
+  - bug fixes
+  - roo code cloud
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.25.19 Release Notes (2025-01-20)
+
+This release fixes an issue with the Roo Code Cloud provider on the welcome screen.
+
+## Bug Fixes
+
+* **Welcome Screen**: Fixed the "Let's go" button not working for Roo Code Cloud provider ([#7239](https://github.com/RooCodeInc/Roo-Code/pull/7239))

--- a/docs/update-notes/v3.25.mdx
+++ b/docs/update-notes/v3.25.mdx
@@ -196,6 +196,7 @@ Critical fixes that improve stability and compatibility:
 * **Terminal Reuse**: Fixed terminal reuse logic to properly handle terminal lifecycle management
 * **LM Studio Models**: Fixed duplicate model entries by implementing case-insensitive deduplication, ensuring models appear only once in the provider configuration
 * **Reasoning Usage**: Fixed enableReasoningEffort setting not being respected when determining reasoning usage, avoiding unintended reasoning costs
+* **Welcome Screen**: Fixed the "Let's go" button not working for Roo Code Cloud provider
 
 ### Provider Updates
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -213,6 +213,7 @@ const sidebars: SidebarsConfig = {
           label: '3.25',
           items: [
             { type: 'doc', id: 'update-notes/v3.25', label: '3.25 Combined' },
+            { type: 'doc', id: 'update-notes/v3.25.19', label: '3.25.19' },
             { type: 'doc', id: 'update-notes/v3.25.18', label: '3.25.18' },
             { type: 'doc', id: 'update-notes/v3.25.17', label: '3.25.17' },
             { type: 'doc', id: 'update-notes/v3.25.16', label: '3.25.16' },


### PR DESCRIPTION
## Summary

This PR adds release notes for Roo Code v3.25.19, which includes a bug fix for the Roo Code Cloud provider.

## Changes

- Created  with release notes for the bug fix
- Updated  to include v3.25.19 in the chronological list
- Updated  to add v3.25.19 to the navigation menu
- Updated  (combined v3.25 notes) with the bug fix

## Release Details

**Version**: 3.25.19  
**Release Date**: 2025-01-20  
**Type**: Bug fix release

### Bug Fix
- Fixed the "Let's go" button not working for Roo Code Cloud provider on the welcome screen (PR #7239)

## Related PRs
- RooCodeInc/Roo-Code#7239 - The actual bug fix in the main repository