### PR TITLE
fix(analytics): guard PostHog session-recording APIs to prevent crash

### DIFF
--- a/src/components/PostHogProvider/index.tsx
+++ b/src/components/PostHogProvider/index.tsx
@@ -1,12 +1,25 @@
 import React, { useEffect } from 'react';
 import { hasConsent, onConsentChange } from '../../lib/analytics/consent-manager';
 
-// PostHog interface - define the methods we use
+// PostHog interface - define only what we use, and guard optional APIs
+type PostHogSetConfig = {
+  disable_session_recording?: boolean;
+};
+
 interface PostHogInstance {
   opt_in_capturing(): void;
   opt_out_capturing(): void;
-  startSessionRecording(): void;
-  stopSessionRecording(): void;
+  set_config?(config: PostHogSetConfig): void;
+
+  // Legacy/direct helpers that may or may not exist on the root instance
+  startSessionRecording?: () => void;
+  stopSessionRecording?: () => void;
+
+  // Namespaced session recording controls in some versions
+  sessionRecording?: {
+    startRecording?: () => void;
+    stopRecording?: () => void;
+  };
 }
 
 declare global {
@@ -39,17 +52,48 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const enablePostHog = () => {
-    if (typeof window !== 'undefined' && window.posthog) {
-      // Re-initialize PostHog if it was previously disabled
-      window.posthog.opt_in_capturing();
-      window.posthog.startSessionRecording();
+    if (typeof window === 'undefined' || !window.posthog) return;
+    const ph = window.posthog;
+
+    // Re-enable analytics if previously opted out
+    try {
+      ph.opt_in_capturing();
+    } catch {
+      // no-op
     }
+
+    // Ensure session recording is enabled via config; don't assume start API exists
+    try {
+      ph.set_config?.({ disable_session_recording: false });
+    } catch {
+      // no-op
+    }
+
+    // Best-effort: try available start methods without crashing if missing
+    ph.startSessionRecording?.();
+    ph.sessionRecording?.startRecording?.();
   };
 
   const disablePostHog = () => {
-    if (typeof window !== 'undefined' && window.posthog) {
-      window.posthog.opt_out_capturing();
-      window.posthog.stopSessionRecording();
+    if (typeof window === 'undefined' || !window.posthog) return;
+    const ph = window.posthog;
+
+    // Disable session recording via config first (works across versions)
+    try {
+      ph.set_config?.({ disable_session_recording: true });
+    } catch {
+      // no-op
+    }
+
+    // Best-effort: try available stop methods without crashing if missing
+    ph.stopSessionRecording?.();
+    ph.sessionRecording?.stopRecording?.();
+
+    // Opt out of all analytics capture if consent is denied
+    try {
+      ph.opt_out_capturing();
+    } catch {
+      // no-op
     }
   };
 


### PR DESCRIPTION
Some users saw a crash: "window.posthog.stopSessionRecording is not a function". Different PostHog bundles/plugins expose session recording controls differently:
- Some expose start/stop on the root (posthog.startSessionRecording / stopSessionRecording)
- Others expose them under posthog.sessionRecording.startRecording / stopRecording
- In all versions, recording can be toggled via set_config({ disable_session_recording })

Changes
- Hardened enable/disable logic in [src/components/PostHogProvider/index.tsx](src/components/PostHogProvider/index.tsx):
  - Flexible interface: [PostHogInstance](src/components/PostHogProvider/index.tsx:9) with optional methods for multiple SDK shapes
  - Consent-driven control via [PostHogProvider()](src/components/PostHogProvider/index.tsx:31)
    - [enablePostHog()](src/components/PostHogProvider/index.tsx:54):
      - Best-effort ph.opt_in_capturing() (try/catch)
      - Use ph.set_config?.({ disable_session_recording: false }) - Attempt ph.startSessionRecording?.() and ph.sessionRecording?.startRecording?.()
    - [disablePostHog()](src/components/PostHogProvider/index.tsx:77): - Use ph.set_config?.({ disable_session_recording: true }) - Attempt ph.stopSessionRecording?.() and ph.sessionRecording?.stopRecording?.() - Best-effort ph.opt_out_capturing() (try/catch)
  - All calls guarded against SSR (typeof window) and undefined window.posthog

Why
- Avoids invoking undefined helpers in environments where the adapter/plugin does not expose them
- set_config({ disable_session_recording }) is widely supported and reliably toggles recording
- Preserves existing consent flow using [hasConsent()](src/lib/analytics/consent-manager.ts:38) and [onConsentChange()](src/lib/analytics/consent-manager.ts:48)

User impact
- Eliminates the crash while maintaining the intended consent behavior

Files touched
- [src/components/PostHogProvider/index.tsx](src/components/PostHogProvider/index.tsx)

Notes
- Editor TS errors for '@roo-code/types', 'react-cookie-consent', and 'tldts' are due to missing local node_modules; they are declared in package.json and resolve in CI/local installs.

Test plan
- Load with consent denied: set_config disables recording; no start/stop calls; no crash
- Accept consent via banner: set_config enables recording; start methods called if present; no crash
- Decline after accepting: set_config disables recording; stop methods called if present; no crash
- Navigate/refresh to ensure stability across routes and SDK variants