### PR TITLE
Fix search on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2333,3 +2333,12 @@ html {
 .menu__list-item:has(> a[href^="https://www.youtube.com/watch"]) {
   margin-bottom: 0 !important;
 }
+
+/* ============================================
+   FIX: SEARCH INPUT TINY BUBBLE ON MOBILE
+   ============================================ */
+
+/* Override Docusaurus default that makes search input 2rem when not focused */
+.navbar__search-input:not(:focus) {
+  min-width: 80px !important;
+}


### PR DESCRIPTION
Before:
<img width="427" height="367" alt="Screenshot 2025-09-27 at 10 52 36 AM" src="https://github.com/user-attachments/assets/c50c8d81-e482-439f-98fe-ab43d7a6d1d3" />

After:
<img width="425" height="363" alt="Screenshot 2025-09-27 at 10 52 12 AM" src="https://github.com/user-attachments/assets/e8ee573f-ada7-4a40-98d4-7c3196a02ad8" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes search input size on mobile by setting a minimum width in `custom.css`.
> 
>   - **CSS Fix**:
>     - In `custom.css`, override default Docusaurus behavior for `.navbar__search-input` to set `min-width: 80px` when not focused, fixing the tiny bubble issue on mobile.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 58458e8d729c40c02bfa662f4c9fa6cc8f85d254. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->