### PR TITLE
feat: add release notes for version 3.28.11 with bug fixes for Claude…

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -20,6 +20,7 @@ image: /img/social-share.jpg
 ### Version 3.28
 
 *   [3.28](/update-notes/v3.28) (Combined)
+*   [3.28.11](/update-notes/v3.28.11) (2025-09-29)
 *   [3.28.10](/update-notes/v3.28.10) (2025-09-29)
 *   [3.28.9](/update-notes/v3.28.9) (2025-09-26)
 *   [3.28.8](/update-notes/v3.28.8) (2025-09-25)

--- a/docs/update-notes/v3.28.11.mdx
+++ b/docs/update-notes/v3.28.11.mdx
@@ -1,0 +1,19 @@
+---
+description: Fixes Claude Sonnet 4.5 model identifiers for AWS Bedrock and OpenRouter to prevent model ID errors.
+keywords:
+  - roo code 3.28.11
+  - bug fixes
+  - bedrock
+  - claude sonnet 4.5
+  - openrouter
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.28.11 Release Notes (2025-09-29)
+
+This patch fixes model identifier issues for Claude Sonnet 4.5 across AWS Bedrock and OpenRouter, so prompts run reliably without ID or selection errors.
+
+## Bug Fixes
+
+* AWS Bedrock: Use the correct Claude Sonnet 4.5 model ID so prompts run without “model not found” errors (thanks sunhyung!) ([#8372](https://github.com/RooCodeInc/Roo-Code/pull/8372))
+* OpenRouter: Correct Claude Sonnet 4.5 model ID format to align with naming and prevent selection/API mismatches ([#8373](https://github.com/RooCodeInc/Roo-Code/pull/8373))

--- a/docs/update-notes/v3.28.mdx
+++ b/docs/update-notes/v3.28.mdx
@@ -101,6 +101,7 @@ This gives teams a higher-capacity OpenAI option without extra configuration.[#8
 ## Bug Fixes
 
 * **AWS Bedrock Claude Sonnet 4.5**: Corrected model identifier for Claude Sonnet 4.5 on AWS Bedrock (thanks sunhyung!) ([#8371](https://github.com/RooCodeInc/Roo-Code/pull/8371))
+* **OpenRouter Claude Sonnet 4.5**: Corrected model ID format to align with naming and prevent selection/API mismatches ([#8373](https://github.com/RooCodeInc/Roo-Code/pull/8373))
 * **GPT-5 LiteLLM Compatibility**: Fixed GPT-5 models failing with LiteLLM provider by using correct `max_completion_tokens` parameter (thanks lx1054331851!) ([#6980](https://github.com/RooCodeInc/Roo-Code/pull/6980))
 * **Fixed "No tool used" Errors**: Resolved the situation where LLMs would sometimes not make tool calls in their response which improves Roo's overall flow. ([#8292](https://github.com/RooCodeInc/Roo-Code/pull/8292))
 * **Context Condensing**: Fixed an issue where the initial task request was being lost during context condensing, causing Roo to try to re-answer the original task ask when resuming after condensing ([#8298](https://github.com/RooCodeInc/Roo-Code/pull/8298))

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -223,6 +223,7 @@ const sidebars: SidebarsConfig = {
           label: '3.28',
           items: [
             { type: 'doc', id: 'update-notes/v3.28', label: '3.28 Combined' },
+            { type: 'doc', id: 'update-notes/v3.28.11', label: '3.28.11' },
             { type: 'doc', id: 'update-notes/v3.28.10', label: '3.28.10' },
             { type: 'doc', id: 'update-notes/v3.28.9', label: '3.28.9' },
             { type: 'doc', id: 'update-notes/v3.28.8', label: '3.28.8' },


### PR DESCRIPTION
… Sonnet 4.5 model identifiers
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added release notes for version 3.28.11, focusing on bug fixes for Claude Sonnet 4.5 model identifiers in AWS Bedrock and OpenRouter.
> 
>   - **Release Notes**:
>     - Added `v3.28.11.mdx` for version 3.28.11 release notes, detailing bug fixes for Claude Sonnet 4.5 model identifiers.
>     - Updated `index.md` to include a link to version 3.28.11 release notes.
>   - **Bug Fixes**:
>     - AWS Bedrock: Corrected Claude Sonnet 4.5 model ID to prevent "model not found" errors.
>     - OpenRouter: Fixed Claude Sonnet 4.5 model ID format to prevent selection/API mismatches.
>   - **Sidebar Update**:
>     - Added `3.28.11` to the `sidebars.ts` under the 3.28 category.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 077d1bf3eab237b053fd955d5efbc45b41a58630. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->