### PR TITLE
docs: v3.28.15 release notes + combined v3.28 updates

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -20,6 +20,7 @@ image: /img/social-share.jpg
 ### Version 3.28
 
 *   [3.28](/update-notes/v3.28) (Combined)
+*   [3.28.15](/update-notes/v3.28.15) (2025-10-03)
 *   [3.28.14](/update-notes/v3.28.14) (2025-09-30)
 *   [3.28.13](/update-notes/v3.28.13) (2025-09-29)
 *   [3.28.12](/update-notes/v3.28.12) (2025-09-29)

--- a/docs/update-notes/v3.28.15.mdx
+++ b/docs/update-notes/v3.28.15.mdx
@@ -1,0 +1,40 @@
+---
+description: Adds new Chutes models, finalized cloud reasoning messages, deprecates Grok 4 Fast, and includes fixes and a Vite security update.
+keywords:
+  - roo code 3.28.15
+  - new models
+  - bug fixes
+  - security update
+image: /img/v3.28.15/v3.28.15.png
+---
+
+# Roo Code 3.28.15 Release Notes (2025-10-03)
+
+This release adds new Chutes models, shows finalized reasoning in cloud tasks, deprecates Grok 4 Fast, and includes UI fixes and security updates.
+
+<img src="/img/v3.28.15/v3.28.15.png" alt="Roo Code v3.28.15 Release" width="600" />
+
+## QOL Improvements
+
+* Include reasoning messages in cloud task histories so you can review complete thinking after runs ([#8401](https://github.com/RooCodeInc/Roo-Code/pull/8401))
+* Add structured data to the homepage to improve SEO and discoverability ([#8427](https://github.com/RooCodeInc/Roo-Code/pull/8427))
+
+## Bug Fixes
+
+* “Reset and Continue” now truly resets cost tracking; subsequent requests only count new costs (thanks alecoot!) ([#6890](https://github.com/RooCodeInc/Roo-Code/pull/6890))
+* Prompts settings: Save button activates on first change and preserves empty strings (thanks beccare!) ([#8267](https://github.com/RooCodeInc/Roo-Code/pull/8267))
+* Remove overeager “unsaved changes” dialog in Settings when nothing changed ([#8410](https://github.com/RooCodeInc/Roo-Code/pull/8410))
+* Show the Send button when only images are attached ([#8423](https://github.com/RooCodeInc/Roo-Code/pull/8423))
+
+## Provider Updates
+
+* Chutes: Add new models for speed, longer context, and multimodal reasoning (DeepSeek V3.1 Terminus, V3.1 turbo, V3.2-Exp; GLM‑4.6‑FP8; Qwen3‑VL‑235B‑A22B‑Thinking) (thanks mohammad154!) ([#8467](https://github.com/RooCodeInc/Roo-Code/pull/8467))
+* Gemini: Remove unsupported free “2.5 Flash Image Preview”; paid path unaffected (thanks SannidhyaSah!) ([#8359](https://github.com/RooCodeInc/Roo-Code/pull/8359))
+* Bedrock: Treat Claude Sonnet 4 as 1M context to reduce truncation and mis-selection ([#8421](https://github.com/RooCodeInc/Roo-Code/pull/8421))
+* Roo Code Cloud: Deprecate “Grok 4 Fast”; show warning if selected and hide when not selected ([#8481](https://github.com/RooCodeInc/Roo-Code/pull/8481))
+
+## Misc Improvements
+
+* Add internal UsageStats schema and type to enable future dashboards and clearer usage insights ([#8441](https://github.com/RooCodeInc/Roo-Code/pull/8441))
+* Security: Update Vite dev server to 6.3.6 to address path traversal (GHSA-g4jq-h2w9-997c) (thanks app/renovate!) ([#7838](https://github.com/RooCodeInc/Roo-Code/pull/7838))
+* Dependency: Update glob to 11.0.3 for stability (thanks app/renovate!) ([#7767](https://github.com/RooCodeInc/Roo-Code/pull/7767))

--- a/docs/update-notes/v3.28.mdx
+++ b/docs/update-notes/v3.28.mdx
@@ -98,6 +98,7 @@ This gives teams a higher-capacity OpenAI option without extra configuration.[#8
 * **Cleaner prompts (no “thinking” tags)**: Removes `<thinking>` tags for cleaner output, fewer tokens, and better model compatibility; preserves the plain‑language rule to confirm tool success. ([#8319](https://github.com/RooCodeInc/Roo-Code/pull/8319))
 * **Simpler Requesty model refresh**: Removes an unnecessary warning when refreshing the Requesty models list so you can fetch new policies without leaving the screen. ([#7710](https://github.com/RooCodeInc/Roo-Code/pull/7710))
 * **Bedrock 1M Context Checkbox**: Adds checkbox to enable 1M context window support for Claude Sonnet 4 and 4.5 on Bedrock, providing more flexibility for large-scale projects ([#8384](https://github.com/RooCodeInc/Roo-Code/pull/8384))
+* Include reasoning messages in cloud task histories so you can review complete thinking after runs ([#8401](https://github.com/RooCodeInc/Roo-Code/pull/8401))
 
 ## Bug Fixes
 
@@ -138,6 +139,10 @@ This gives teams a higher-capacity OpenAI option without extra configuration.[#8
 
 * **AWS Bedrock**: Removed `topP` parameter to avoid conflicts with extended thinking, improving reliability for streaming and non‑streaming responses (thanks ronyblum!) ([#8388](https://github.com/RooCodeInc/Roo-Code/pull/8388))
 * **Vertex AI**: Fixed Sonnet 4.5 model configuration to prevent 404s and align with the correct default model ID (thanks nickcatal!) ([#8391](https://github.com/RooCodeInc/Roo-Code/pull/8391))
+* "Reset and Continue" now truly resets cost tracking; subsequent requests only count new message costs ([#6890](https://github.com/RooCodeInc/Roo-Code/pull/6890))
+* Prompts settings: Save button activates on first change and preserves empty strings ([#8267](https://github.com/RooCodeInc/Roo-Code/pull/8267))
+* Settings: Remove overeager "unsaved changes" dialog when nothing changed ([#8410](https://github.com/RooCodeInc/Roo-Code/pull/8410))
+* Show the Send button when only images are attached ([#8423](https://github.com/RooCodeInc/Roo-Code/pull/8423))
 
 ## Provider Updates
 
@@ -152,6 +157,10 @@ This gives teams a higher-capacity OpenAI option without extra configuration.[#8
 
 * **Supernova 1M context**: Upgrades the default Supernova to roo/code-supernova-1-million (1,000,000‑token context). Existing settings auto‑migrate; expect fewer truncations on long tasks. ([#8330](https://github.com/RooCodeInc/Roo-Code/pull/8330))
 * **Z.ai GLM‑4.6**: Adds GLM‑4.6 model support with a 200k (204,800) context window and availability across both international and mainland API lines (thanks dmarkey!) ([#8408](https://github.com/RooCodeInc/Roo-Code/pull/8408))
+* **Chutes**: Add DeepSeek‑V3.1‑Terminus, DeepSeek‑V3.1‑turbo, DeepSeek‑V3.2‑Exp, GLM‑4.6‑FP8, and Qwen3‑VL‑235B‑A22B‑Thinking to the provider picker ([#8467](https://github.com/RooCodeInc/Roo-Code/pull/8467))
+* **Gemini**: Remove unsupported free “2.5 Flash Image Preview”; paid path unaffected ([#8359](https://github.com/RooCodeInc/Roo-Code/pull/8359))
+* **Roo Code Cloud**: Deprecate “Grok 4 Fast”; show warning if selected and hide when not selected ([#8481](https://github.com/RooCodeInc/Roo-Code/pull/8481))
+* **Bedrock**: Claude Sonnet 4 1M‑context handling and compatibility improvements ([#8421](https://github.com/RooCodeInc/Roo-Code/pull/8421))
 
 ## Misc Improvements
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -223,6 +223,7 @@ const sidebars: SidebarsConfig = {
           label: '3.28',
           items: [
             { type: 'doc', id: 'update-notes/v3.28', label: '3.28 Combined' },
+            { type: 'doc', id: 'update-notes/v3.28.15', label: '3.28.15' },
             { type: 'doc', id: 'update-notes/v3.28.14', label: '3.28.14' },
             { type: 'doc', id: 'update-notes/v3.28.13', label: '3.28.13' },
             { type: 'doc', id: 'update-notes/v3.28.12', label: '3.28.12' },


### PR DESCRIPTION
docs: v3.28.15 release notes and combined v3.28 updates

Changes:
- Add patch notes: docs/update-notes/v3.28.15.mdx
- Update combined notes: docs/update-notes/v3.28.mdx (adds cloud reasoning messages, fixes, provider updates)
- Update index and sidebar: docs/update-notes/index.md, sidebars.ts
- Provider docs updates:
  - docs/providers/chutes.md — add new models (PR #8467)
  - docs/providers/bedrock.md — clarify 1M-context handling for Claude Sonnet 4 (PR #8421)
  - docs/providers/roo-code-cloud.md — deprecate "Grok 4 Fast" UI behavior (PR #8481)

Notes:
- Date: 2025-10-03
- Hero image: /img/v3.28.15/v3.28.15.png
